### PR TITLE
Added compatibility with fabric intermediary mappings

### DIFF
--- a/src/net/minecraft/src/CraftGuide_Vanilla.java
+++ b/src/net/minecraft/src/CraftGuide_Vanilla.java
@@ -139,8 +139,8 @@ public class CraftGuide_Vanilla implements CraftGuideLoaderSide
 				{
 					int x = Mouse.getX() * screen.width / mc.displayWidth;
 					int y = screen.height - (Mouse.getY() * screen.height / mc.displayHeight) - 1;
-					int left = (Integer)CommonUtilities.getPrivateValue(GuiContainer.class, (GuiContainer)screen, "e", "n", "field_74198_m", "guiLeft");
-					int top = (Integer)CommonUtilities.getPrivateValue(GuiContainer.class, (GuiContainer)screen, "o", "field_74197_n", "guiTop");
+					int left = (Integer)CommonUtilities.getPrivateValue(GuiContainer.class, (GuiContainer)screen, "e", "n", "field_74198_m", "guiLeft", "field_1350");
+					int top = (Integer)CommonUtilities.getPrivateValue(GuiContainer.class, (GuiContainer)screen, "o", "field_74197_n", "guiTop", "field_1351");
 					openRecipe((GuiContainer)screen, x - left, y - top);
 				}
 				catch(IllegalArgumentException e)

--- a/src/uristqwerty/CraftGuide/CommonUtilities.java
+++ b/src/uristqwerty/CraftGuide/CommonUtilities.java
@@ -209,7 +209,7 @@ public class CommonUtilities
 	{
 		try
 		{
-			itemDamageField = getPrivateField(ItemStack.class, "itemDamage", "field_77991_e", "e");
+			itemDamageField = getPrivateField(ItemStack.class, "itemDamage", "field_77991_e", "e", "field_4380");
 		}
 		catch(NoSuchFieldException e)
 		{

--- a/src/uristqwerty/CraftGuide/RecipeGeneratorImplementation.java
+++ b/src/uristqwerty/CraftGuide/RecipeGeneratorImplementation.java
@@ -156,9 +156,9 @@ public class RecipeGeneratorImplementation implements RecipeGenerator
 		{
 			if(recipe instanceof ShapedRecipes)
 			{
-				int width = (Integer)CommonUtilities.getPrivateValue(ShapedRecipes.class, (ShapedRecipes)recipe, "b", "recipeWidth", "field_77576_b");
-				int height = (Integer)CommonUtilities.getPrivateValue(ShapedRecipes.class, (ShapedRecipes)recipe, "c", "recipeHeight", "field_77577_c");
-				Object[] items = (Object[])CommonUtilities.getPrivateValue(ShapedRecipes.class, (ShapedRecipes)recipe, "d", "recipeItems", "field_77574_d");
+				int width = (Integer)CommonUtilities.getPrivateValue(ShapedRecipes.class, (ShapedRecipes)recipe, "b", "recipeWidth", "field_77576_b", "field_4438");
+				int height = (Integer)CommonUtilities.getPrivateValue(ShapedRecipes.class, (ShapedRecipes)recipe, "c", "recipeHeight", "field_77577_c", "field_4439");
+				Object[] items = (Object[])CommonUtilities.getPrivateValue(ShapedRecipes.class, (ShapedRecipes)recipe, "d", "recipeItems", "field_77574_d", "field_4440");
 
 				if(allowSmallGrid && width < 3 && height < 3)
 				{
@@ -171,7 +171,7 @@ public class RecipeGeneratorImplementation implements RecipeGenerator
 			}
 			else if(recipe instanceof ShapelessRecipes)
 			{
-				List items = (List)CommonUtilities.getPrivateValue(ShapelessRecipes.class, (ShapelessRecipes)recipe, "b", "recipeItems", "field_77579_b");
+				List items = (List)CommonUtilities.getPrivateValue(ShapelessRecipes.class, (ShapelessRecipes)recipe, "b", "recipeItems", "field_77579_b", "field_4443");
 				return getCraftingShapelessRecipe(items, ((ShapelessRecipes)recipe).getRecipeOutput());
 			}
 			else if(forgeExt != null && forgeExt.matchesType(recipe))

--- a/src/uristqwerty/CraftGuide/client/vanilla/CraftGuideClient_Vanilla.java
+++ b/src/uristqwerty/CraftGuide/client/vanilla/CraftGuideClient_Vanilla.java
@@ -45,7 +45,7 @@ public class CraftGuideClient_Vanilla extends CraftGuideClient
 
 		try
 		{
-			TexturePackList texturePackList = (TexturePackList)CommonUtilities.getPrivateValue(RenderEngine.class, renderEngine, "g", "texturePack", "field_78366_k");
+			TexturePackList texturePackList = (TexturePackList)CommonUtilities.getPrivateValue(RenderEngine.class, renderEngine, "g", "texturePack", "field_78366_k", "field_1981");
 			return texturePackList.getSelectedTexturePack();
 		}
 		catch(SecurityException e)
@@ -75,7 +75,7 @@ public class CraftGuideClient_Vanilla extends CraftGuideClient
 		{
 			try
 			{
-				isDrawing = CommonUtilities.getPrivateField(Tessellator.class, "z", "isDrawing", "field_78415_z");
+				isDrawing = CommonUtilities.getPrivateField(Tessellator.class, "z", "isDrawing", "field_78415_z", "field_1970");
 			}
 			catch(NoSuchFieldException e)
 			{

--- a/src/uristqwerty/gui_craftguide/minecraft/Image.java
+++ b/src/uristqwerty/gui_craftguide/minecraft/Image.java
@@ -44,7 +44,7 @@ public class Image implements Texture
 					Method getTexture;
 					try
 					{
-						getTexture = CommonUtilities.getPrivateMethod(RenderEngine.class, new String[]{"f", "getTexture", "func_78341_b"}, String.class);
+						getTexture = CommonUtilities.getPrivateMethod(RenderEngine.class, new String[]{"f", "getTexture", "func_78341_b", "method_1428"}, String.class);
 						image.texID = (Integer)getTexture.invoke(Minecraft.getMinecraft().renderEngine, entry.getKey());
 					}
 					catch(NoSuchMethodException e)


### PR DESCRIPTION
This makes CraftGuide BTW-CE compatible with a fabric environment simply by adding the fabric intermediary names to the lookup-lists.

No other functional changes, works in a fabric environment and should work in a normal obfuscated environment as well.
[CraftGuide-BTW-CE-Fabric-v1.3.zip](https://github.com/BTW-Community/CraftGuide/files/8185675/CraftGuide-BTW-CE-Fabric-v1.3.zip)
 